### PR TITLE
Update my fork

### DIFF
--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: latest
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 1.0.0
+version: 1.0.1
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -135,15 +135,12 @@ spec:
           hostPath:
             path: /var/lib/kubelet/pods
             type: Directory
-    {{- if .Values.controllerplugin.affinity -}}
-      affinity:
-{{ toYaml .Values.controllerplugin.affinity . | indent 8 }}
-    {{- end -}}
-    {{- if .Values.controllerplugin.nodeSelector -}}
-      nodeSelector:
-{{ toYaml .Values.controllerplugin.nodeSelector | indent 8 }}
-    {{- end -}}
-    {{- if .Values.controllerplugin.tolerations -}}
-      tolerations:
-{{ toYaml .Values.controllerplugin.tolerations | indent 8 }}
-    {{- end -}}
+    {{- if .Values.controllerplugin.affinity }}
+      affinity: {{ toYaml .Values.controllerplugin.affinity | nindent 8 }}
+    {{- end }}
+    {{- if .Values.controllerplugin.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.controllerplugin.nodeSelector | nindent 8 }}
+    {{- end }}
+    {{- if .Values.controllerplugin.tolerations }}
+      tolerations: {{ toYaml .Values.controllerplugin.tolerations | nindent 8 }}
+    {{- end }}

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -125,15 +125,12 @@ spec:
             name: manila-csi-runtimeconf-cm
         {{- end }}
         {{- end }}
-    {{- if .Values.nodeplugin.affinity -}}
-      affinity:
-{{ toYaml .Values.nodeplugin.affinity . | indent 8 }}
-    {{- end -}}
-    {{- if .Values.nodeplugin.nodeSelector -}}
-      nodeSelector:
-{{ toYaml .Values.nodeplugin.nodeSelector | indent 8 }}
-    {{- end -}}
-    {{- if .Values.nodeplugin.tolerations -}}
-      tolerations:
-{{ toYaml .Values.nodeplugin.tolerations | indent 8 }}
-    {{- end -}}
+    {{- if .Values.nodeplugin.affinity }}
+      affinity: {{ toYaml .Values.nodeplugin.affinity | nindent 8 }}
+    {{- end }}
+    {{- if .Values.nodeplugin.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.nodeplugin.nodeSelector | nindent 8 }}
+    {{- end }}
+    {{- if .Values.nodeplugin.tolerations }}
+      tolerations: {{ toYaml .Values.nodeplugin.tolerations | nindent 8 }}
+    {{- end }}

--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -1441,8 +1441,11 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 		return nil, fmt.Errorf("failed to get listeners for load balancer %s: %v", loadbalancer.Name, err)
 	}
 
+	// Copy elements from oldListeners to a new slice which doesn't change during the iteration.
+	listenersCopy := make([]listeners.Listener, len(oldListeners))
+	copy(listenersCopy, oldListeners)
 	for _, port := range service.Spec.Ports {
-		listener, err := lbaas.ensureOctaviaListener(loadbalancer.ID, oldListeners, service, port, svcConf)
+		listener, err := lbaas.ensureOctaviaListener(loadbalancer.ID, listenersCopy, service, port, svcConf)
 		if err != nil {
 			return nil, err
 		}

--- a/tests/e2e/cloudprovider/test-lb-service.sh
+++ b/tests/e2e/cloudprovider/test-lb-service.sh
@@ -14,6 +14,19 @@ TIMEOUT=${TIMEOUT:-300}
 FLOATING_IP=${FLOATING_IP:-""}
 NAMESPACE="octavia-lb-test"
 
+delete_resources() {
+  ERROR_CODE="$?"
+
+  printf "\n>>>>>>> Deleting k8s resources\n"
+  for name in "test-basic" "test-x-forwarded-for" "test-update-port"; do
+    kubectl -n $NAMESPACE delete service ${name}
+  done
+  kubectl -n ${NAMESPACE} delete deploy echoserver
+
+  exit ${ERROR_CODE}
+}
+trap "delete_resources" EXIT;
+
 ########################################################################
 ## Name: wait_for_service
 ## Desc: Waits for a k8s service until it gets a valid IP address
@@ -33,7 +46,36 @@ function wait_for_service {
     fi
     sleep 3
     now=$(date +%s)
-    [ $now -gt $end ] && printf "\n>>>>>>> FAIL: Failed to wait for the Service ${service_name} created in time\n" && exit -1
+    [ $now -gt $end ] && printf "\n>>>>>>> FAIL: Timeout when waiting for the Service ${service_name} created\n" && exit -1
+  done
+}
+
+########################################################################
+## Name: wait_for_loadbalancer
+## Desc: Waits for the load balancer to be ACTIVE
+## Params:
+##   - (required) The load balancer ID.
+########################################################################
+function wait_for_loadbalancer {
+  local lbid=$1
+  local i=0
+
+  end=$(($(date +%s) + ${TIMEOUT}))
+  while true; do
+    status=$(kubectl -n $NAMESPACE exec openstackcli -- openstack loadbalancer show $lbid -f value -c provisioning_status)
+    if [[ $status == "ACTIVE" ]]; then
+      if [[ $i == 2 ]]; then
+        printf "\n>>>>>>> Load balancer ${lbid} is ACTIVE\n"
+        break
+      fi
+      let i++
+    else
+      i=0
+    fi
+
+    sleep 3
+    now=$(date +%s)
+    [ $now -gt $end ] && printf "\n>>>>>>> FAIL: Timeout when waiting for the load balancer ${lbid} ACTIVE\n" && exit -1
   done
 }
 
@@ -107,6 +149,37 @@ spec:
         ports:
           - containerPort: 8080
 EOF
+}
+
+########################################################################
+## Name: create_openstackcli_pod
+## Desc: Makes sure the openstackcli pod is running.
+## Params: None
+########################################################################
+function create_openstackcli_pod {
+    kubectl -n $NAMESPACE get pod | grep openstackcli | grep Running > /dev/null
+    if [[ $? -eq 1 ]]; then
+      printf "\n>>>>>>> Creating openstackcli pod\n"
+      cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: openstackcli
+  namespace: $NAMESPACE
+spec:
+  containers:
+    - name: openstackcli
+      image: lingxiankong/openstack-cli:1.0.0
+      envFrom:
+      - secretRef:
+          name: openrc
+      command:
+        - sleep
+        - "3600"
+EOF
+    kubectl -n $NAMESPACE wait --for=condition=Ready pod/openstackcli
+    printf "\n>>>>>>> Pod openstackcli created.\n"
+    fi
 }
 
 ########################################################################
@@ -198,10 +271,104 @@ EOF
     kubectl -n $NAMESPACE delete service ${service}
 }
 
+########################################################################
+## Name: test_update_port
+## Desc: Create a k8s service and update the service port/nodeport.
+## Params: None
+########################################################################
+function test_update_port {
+    local service="test-update-port"
+
+    printf "\n>>>>>>> Creating Service ${service}\n"
+    cat <<EOF | kubectl apply -f -
+kind: Service
+apiVersion: v1
+metadata:
+  name: ${service}
+  namespace: $NAMESPACE
+  annotations:
+    service.beta.kubernetes.io/openstack-internal-load-balancer: "true"
+spec:
+  type: LoadBalancer
+  selector:
+    run: echoserver
+  ports:
+    - name: port1
+      protocol: TCP
+      port: 80
+      targetPort: 8080
+    - name: port2
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+EOF
+
+    printf "\n>>>>>>> Waiting for the Service ${service} created\n"
+    wait_for_service ${service}
+
+    printf "\n>>>>>>> Validating openstack load balancer\n"
+    create_openstackcli_pod
+    lbid=$(kubectl -n $NAMESPACE exec openstackcli -- openstack loadbalancer list -c id -c name | grep "octavia-lb-test_${service}" | awk '{print $2}')
+    lb_info=$(kubectl -n $NAMESPACE exec openstackcli -- openstack loadbalancer status show $lbid)
+    listener_count=$(echo $lb_info | jq '.loadbalancer.listeners | length')
+    member_ports=$(echo $lb_info | jq '.loadbalancer.listeners | .[].pools | .[].members | .[].protocol_port' | uniq)
+    service_nodeports=$(kubectl -n $NAMESPACE  get svc $service -o json | jq '.spec.ports | .[].nodePort')
+
+    if [[ ${listener_count} != 2 ]]; then
+        printf "\n>>>>>>> FAIL: Unexpected number of listeners(${listener_count}) created for service ${service}\n"
+        exit -1
+    fi
+    if [[ ${member_ports} != ${service_nodeports} ]]; then
+        printf "\n>>>>>>> FAIL: Member ports ${member_ports} and service nodeport ${service_nodeports} not match\n"
+        exit -1
+    fi
+
+    printf "\n>>>>>>> Expected: NodePorts ${member_ports} before updating service.\n"
+
+    printf "\n>>>>>>> Removing port2 and update NodePort of port1.\n"
+    kubectl patch svc $service --type json -p '[{"op": "remove","path": "/spec/ports/1"},{"op": "remove","path": "/spec/ports/0/nodePort"}]'
+
+    printf "\n>>>>>>> Waiting for load balancer $lbid ACTIVE.\n"
+    wait_for_loadbalancer $lbid
+
+    printf "\n>>>>>>> Validating openstack load balancer after updating the service.\n"
+    create_openstackcli_pod
+    lb_info=$(kubectl -n $NAMESPACE exec openstackcli -- openstack loadbalancer status show $lbid)
+    listener_count=$(echo $lb_info | jq '.loadbalancer.listeners | length')
+    member_port=$(echo $lb_info | jq '.loadbalancer.listeners | .[].pools | .[].members | .[].protocol_port' | uniq)
+    service_nodeport=$(kubectl -n $NAMESPACE  get svc $service -o json | jq '.spec.ports | .[].nodePort')
+
+    if [[ ${listener_count} != 1 ]]; then
+        printf "\n>>>>>>> FAIL: Unexpected number of listeners(${listener_count}) for service.\n"
+        exit -1
+    fi
+    if [[ $(echo ${member_port} | wc -l) != 1 ]]; then
+        printf "\n>>>>>>> FAIL: Unexpected number of member port(${member_port}) for service.\n"
+        exit -1
+    fi
+    if [[ ${member_port} != ${service_nodeport} ]]; then
+        printf "\n>>>>>>> FAIL: Member ports ${member_port} and service nodeport ${service_nodeport} not match.\n"
+        exit -1
+    fi
+    if [[ ${member_port} == ${member_ports} ]]; then
+        printf "\n>>>>>>> FAIL: NodePort ${member_port} not changed.\n"
+        exit -1
+    fi
+    echo ${member_ports} | grep -w ${member_port}
+    if [[ $? -eq 0 ]]; then
+        printf "\n>>>>>>> FAIL: NodePort ${member_port} should not in ${member_ports}.\n"
+        exit -1
+    fi
+
+    printf "\n>>>>>>> Expected: NodePort ${member_port} after updating service.\n"
+
+    printf "\n>>>>>>> Deleting Service ${service}\n"
+    kubectl -n $NAMESPACE delete service ${service}
+}
+
 create_namespace
 create_deployment
+
 test_basic
 test_forwarded
-
-printf "\n>>>>>>> Delete k8s resources\n"
-kubectl -n ${NAMESPACE} delete deploy echoserver
+test_update_port


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
